### PR TITLE
Upgrade Solidity to version 0.8.0

### DIFF
--- a/packages/contracts/.waffle.json
+++ b/packages/contracts/.waffle.json
@@ -1,5 +1,5 @@
 {
-  "compilerVersion": "0.7.0",
+  "compilerVersion": "v0.8.0+commit.c7dfd78e",
   "outputType": "minimal",
   "compilerOptions": {
     "optimizer": {

--- a/packages/contracts/contracts/TenCounter.sol
+++ b/packages/contracts/contracts/TenCounter.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.7.0;
+pragma solidity =0.8.0;
 
 import './libraries/Math.sol';
 import './interfaces/ITenCounter.sol';

--- a/packages/contracts/contracts/interfaces/ITenCounter.sol
+++ b/packages/contracts/contracts/interfaces/ITenCounter.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.7.0;
+pragma solidity =0.8.0;
 
 interface ITenCounter {
     function value() external view returns (uint256);

--- a/packages/contracts/contracts/libraries/Math.sol
+++ b/packages/contracts/contracts/libraries/Math.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.7.0;
+pragma solidity =0.8.0;
 
 library Math {
     function min(uint256 x, uint256 y) internal pure returns (uint256 z) {

--- a/packages/contracts/contracts/test/MathTest.sol
+++ b/packages/contracts/contracts/test/MathTest.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.7.0;
+pragma solidity =0.8.0;
 
 import '../libraries/Math.sol';
 


### PR DESCRIPTION
This allows to poll RPC providers before Metamask is plugged in